### PR TITLE
Add userstyle for making Phabricator workboard more compact

### DIFF
--- a/phabricator-compact-workboard.user.css
+++ b/phabricator-compact-workboard.user.css
@@ -1,0 +1,18 @@
+/* ==UserStyle==
+@name           Make compact Phabricator workboard
+@namespace      wikimedia.se
+@version        1.0.1
+@description    Make Phabricator workboard more compact by removing sidebar.
+@author         André Costa <andre.costa@wikimedia.se>
+@updateURL      https://github.com/Wikimedia-Sverige/scripts/raw/master/phabricator-compact-workboard.user.css
+@license        CC0-1.0
+==/UserStyle== */
+@-moz-document url-prefix("https://phabricator.wikimedia.org/tag/") {
+    .phabricator-side-menu {
+        display: none !important;
+    }
+
+    .phui-workboard-view-shadow {
+        left: 0 !important;
+    }
+}

--- a/phabricator-compact-workboard.user.css
+++ b/phabricator-compact-workboard.user.css
@@ -7,7 +7,7 @@
 @updateURL      https://github.com/Wikimedia-Sverige/scripts/raw/master/phabricator-compact-workboard.user.css
 @license        CC0-1.0
 ==/UserStyle== */
-@-moz-document url-prefix("https://phabricator.wikimedia.org/tag/") {
+@-moz-document regexp("https://phabricator.wikimedia.org/(project/(view|board)|tag)/.*") {
     .phabricator-side-menu {
         display: none !important;
     }

--- a/phabricator-compact-workboard.user.css
+++ b/phabricator-compact-workboard.user.css
@@ -8,11 +8,11 @@
 @license        CC0-1.0
 ==/UserStyle== */
 @-moz-document regexp("https://phabricator.wikimedia.org/(project/(view|board)|tag)/.*") {
-    .phabricator-side-menu {
-        display: none !important;
+    #phabricator-standard-page-body .phabricator-side-menu {
+        display: none;
     }
 
-    .phui-workboard-view-shadow {
-        left: 0 !important;
+    #phabricator-standard-page-body .phui-workboard-view-shadow {
+        left: 0;
     }
 }


### PR DESCRIPTION
Usefull when splitting the screen during e.g. weekly check-ins
with remote collegues.